### PR TITLE
Replace calls to #update with #update! in specs

### DIFF
--- a/app/models/brand_account.rb
+++ b/app/models/brand_account.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BrandAccount < ApplicationRecord
-  include Account
+  include Accountable
 
   validates :external_uid, uniqueness: { scope: :provider }
   validates :provider, presence: true, uniqueness: { scope: :brand_id }

--- a/app/models/concerns/accountable.rb
+++ b/app/models/concerns/accountable.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Account
+module Accountable
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/user_account.rb
+++ b/app/models/user_account.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UserAccount < ApplicationRecord
-  include Account
+  include Accountable
 
   validates :external_uid, uniqueness: { scope: :provider }
   validates :provider, presence: true, uniqueness: { scope: :user_id }

--- a/spec/helpers/tickets_helper_spec.rb
+++ b/spec/helpers/tickets_helper_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe TicketsHelper, type: :helper do
 
     context 'when ticket is root' do
       before do
-        ticket.update(parent: nil)
+        ticket.update!(parent: nil)
       end
 
       it 'shows provider' do

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Author, type: :model do
 
       context 'when username does not change' do
         before do
-          author.update(username: twitter_user.screen_name)
+          author.update!(username: twitter_user.screen_name)
         end
 
         it 'does not update username' do
@@ -105,7 +105,7 @@ RSpec.describe Author, type: :model do
 
       context 'when username does not change' do
         before do
-          author.update(username: disqus_user[:username])
+          author.update!(username: disqus_user[:username])
         end
 
         it 'does not update username' do
@@ -164,7 +164,7 @@ RSpec.describe Author, type: :model do
 
       context 'when username does not change' do
         before do
-          author.update(username: external_author_json[:username])
+          author.update!(username: external_author_json[:username])
         end
 
         it 'does not update username' do

--- a/spec/models/brand_account_spec.rb
+++ b/spec/models/brand_account_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe BrandAccount, type: :model do
 
           context 'when email does not change' do
             before do
-              account.update(email: auth_hash.info.email)
+              account.update!(email: auth_hash.info.email)
             end
 
             it 'does not update email' do
@@ -171,7 +171,7 @@ RSpec.describe BrandAccount, type: :model do
 
           context 'when token does not change' do
             before do
-              account.update(token: auth_hash.credentials.token)
+              account.update!(token: auth_hash.credentials.token)
             end
 
             it 'does not update token' do
@@ -187,7 +187,7 @@ RSpec.describe BrandAccount, type: :model do
 
           context 'when secret does not change' do
             before do
-              account.update(secret: auth_hash.credentials.secret)
+              account.update!(secret: auth_hash.credentials.secret)
             end
 
             it 'does not update secret' do

--- a/spec/models/brand_account_spec.rb
+++ b/spec/models/brand_account_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/support/concerns/models/account_examples.rb'
+require './spec/support/concerns/models/accountable_examples.rb'
 
 RSpec.describe BrandAccount, type: :model do
   describe 'Validations' do
@@ -17,7 +17,7 @@ RSpec.describe BrandAccount, type: :model do
     it { is_expected.to belong_to(:brand) }
   end
 
-  it_behaves_like 'account'
+  it_behaves_like 'accountable'
 
   describe '.from_omniauth' do
     described_class.providers.keys.each do |provider|

--- a/spec/models/external_ticket_spec.rb
+++ b/spec/models/external_ticket_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ExternalTicket, type: :model do
 
     context 'when ticket has custom provider' do
       before do
-        external_ticket.update(custom_provider: 'hacker_news')
+        external_ticket.update!(custom_provider: 'hacker_news')
       end
 
       it { is_expected.to eq('hacker_news') }

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Subscription, type: :model do
     [[:trialing, true], [:active, true], [:past_due, true], [:deleted, false]].each do |status_pair|
       context "when status is #{status_pair.first}" do
         before do
-          subscription.update(status: status_pair.first)
+          subscription.update!(status: status_pair.first)
         end
 
         it { is_expected.to eq(status_pair.second) }

--- a/spec/models/user_account_spec.rb
+++ b/spec/models/user_account_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require './spec/support/concerns/models/account_examples.rb'
+require './spec/support/concerns/models/accountable_examples.rb'
 
 RSpec.describe UserAccount, type: :model do
   describe 'Validations' do
@@ -17,7 +17,7 @@ RSpec.describe UserAccount, type: :model do
     it { is_expected.to belong_to(:user) }
   end
 
-  it_behaves_like 'account'
+  it_behaves_like 'accountable'
 
   describe '.from_omniauth' do
     described_class.providers.keys.each do |provider|

--- a/spec/models/user_account_spec.rb
+++ b/spec/models/user_account_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe UserAccount, type: :model do
 
           context 'when email does not change' do
             before do
-              account.update(email: auth_hash.info.email)
+              account.update!(email: auth_hash.info.email)
             end
 
             it 'does not update email' do
@@ -233,7 +233,7 @@ RSpec.describe UserAccount, type: :model do
 
           context 'when token does not change' do
             before do
-              account.update(token: auth_hash.credentials.token)
+              account.update!(token: auth_hash.credentials.token)
             end
 
             it 'does not update token' do
@@ -249,7 +249,7 @@ RSpec.describe UserAccount, type: :model do
 
           context 'when secret does not change' do
             before do
-              account.update(secret: auth_hash.credentials.secret)
+              account.update!(secret: auth_hash.credentials.secret)
             end
 
             it 'does not update secret' do

--- a/spec/requests/brands/tickets_controller_spec.rb
+++ b/spec/requests/brands/tickets_controller_spec.rb
@@ -259,7 +259,7 @@ RSpec.describe Brands::TicketsController, type: :request do
                 account_provider = ticket.external? ? 'twitter' : ticket.provider
                 FactoryBot.create(:brand_account, provider: account_provider, brand: brand)
 
-                user.update(brand: brand)
+                user.update!(brand: brand)
               end
 
               context 'when reply is valid' do
@@ -319,7 +319,7 @@ RSpec.describe Brands::TicketsController, type: :request do
 
         context 'when user is authorized' do
           before do
-            user.update(brand: brand)
+            user.update!(brand: brand)
           end
 
           context 'when internal note is valid' do
@@ -395,12 +395,12 @@ RSpec.describe Brands::TicketsController, type: :request do
 
         context 'when user is authorized' do
           before do
-            user.update(brand: brand)
+            user.update!(brand: brand)
           end
 
           context 'when the ticket is open' do
             before do
-              ticket.update(status: 'open')
+              ticket.update!(status: 'open')
             end
 
             it 'solves the ticket' do
@@ -422,7 +422,7 @@ RSpec.describe Brands::TicketsController, type: :request do
 
           context 'when the ticket is solved' do
             before do
-              ticket.update(status: 'solved')
+              ticket.update!(status: 'solved')
             end
 
             it 'opens the ticket' do

--- a/spec/requests/brands/users_controller_spec.rb
+++ b/spec/requests/brands/users_controller_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe Brands::UsersController, type: :request do
         end
 
         context 'when removing other user from brand' do
-          it_behaves_like 'removes user from brand' do
+          include_examples 'removes user from brand' do
             let(:redirect_path) { edit_brand_path(brand) }
           end
         end
@@ -173,7 +173,7 @@ RSpec.describe Brands::UsersController, type: :request do
         context 'when user is removing self from brand' do
           let(:user) { browsing_user }
 
-          it_behaves_like 'removes user from brand' do
+          include_examples 'removes user from brand' do
             let(:redirect_path) { root_path }
           end
         end

--- a/spec/support/concerns/models/accountable_examples.rb
+++ b/spec/support/concerns/models/accountable_examples.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.shared_examples 'account' do
+RSpec.shared_examples 'accountable' do
   describe 'Validations' do
     subject(:account) { FactoryBot.create(described_class.to_s.underscore) }
 

--- a/spec/support/system/allows_interacting_with_tickets_examples.rb
+++ b/spec/support/system/allows_interacting_with_tickets_examples.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples 'allows interacting with tickets' do
     sign_in_brand(brand)
 
     account = brand.accounts.first
-    account.update(token: 'hello', secret: 'world')
+    account.update!(token: 'hello', secret: 'world')
 
     response_text = 'Hello from Respondo system tests'
     stub_twitter_reply_response(

--- a/spec/system/brand_spec.rb
+++ b/spec/system/brand_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe 'Brand', type: :system do
 
     it 'keeps ticket status context when searching' do
       solved_tickets = FactoryBot.create_list(:internal_ticket, 2, status: :solved, brand: brand).map(&:base_ticket)
-      tickets.first.update(content: solved_tickets.first.content)
+      tickets.first.update!(content: solved_tickets.first.content)
 
       sign_in_user
       sign_in_brand(brand)

--- a/spec/views/brands/tickets/_ticket.html.haml_spec.rb
+++ b/spec/views/brands/tickets/_ticket.html.haml_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'brands/tickets/_ticket', type: :view do
 
   context 'when ticket has user' do
     before do
-      ticket.update(user: user)
+      ticket.update!(user: user)
     end
 
     it 'displays user along with author' do


### PR DESCRIPTION
# Summary

- Replaces calls to `#update` with `#update!` in specs
- Renames `Account` to `Accountable`