### PR TITLE
Hide brand subscription section behind feature flag

### DIFF
--- a/app/policies/brand_policy.rb
+++ b/app/policies/brand_policy.rb
@@ -12,7 +12,7 @@ class BrandPolicy < ApplicationPolicy
   end
 
   def subscription?
-    Flipper.enabled?(:skip_subscription_check) ||
+    Flipper.enabled?(:disable_subscriptions) ||
       record.subscription&.running?
   end
 

--- a/app/views/brands/edit.html.haml
+++ b/app/views/brands/edit.html.haml
@@ -38,21 +38,21 @@
       = update_brand_form.text_field :domain, required: true, placeholder: 'domain.com', class: 'form-control col-8'
       = update_brand_form.submit 'Update', name: nil, class: 'btn btn-primary col-3 ml-auto'
 
-%hr
+- unless Flipper.enabled?(:disable_subscriptions)
+  %hr
 
-.row
-  .col-12
-    %h3 Subscription
-    %p.lead Manage your subscription.
-    %p
-      Subscription status:
-      %span.badge{ class: "badge-#{subscription_badge_class(subscription_status)}" }= subscription_status || 'no subscription'
-    - if brand.subscription&.running?
-      = button_tag 'Update Payment Details', class: 'btn btn-light', id: 'update-subscription'
-      = button_tag 'Cancel Subscription', class: 'btn btn-light', id: 'cancel-subscription'
-    - else
-      = button_tag 'Buy Subscription', class: 'btn btn-light', id: 'buy-subscription'
-
+  .row
+    .col-12
+      %h3 Subscription
+      %p.lead Manage your subscription.
+      %p
+        Subscription status:
+        %span.badge{ class: "badge-#{subscription_badge_class(subscription_status)}" }= subscription_status || 'no subscription'
+      - if brand.subscription&.running?
+        = button_tag 'Update Payment Details', class: 'btn btn-light', id: 'update-subscription'
+        = button_tag 'Cancel Subscription', class: 'btn btn-light', id: 'cancel-subscription'
+      - else
+        = button_tag 'Buy Subscription', class: 'btn btn-light', id: 'buy-subscription'
 
 = content_for :custom_javascript do
   %script{ src: 'https://cdn.paddle.com/paddle/paddle.js' }

--- a/app/views/brands/tickets/_ticket.html.haml
+++ b/app/views/brands/tickets/_ticket.html.haml
@@ -11,7 +11,7 @@
           %span.font-weight-bold.mr-1 #{internal_note.creator.name}:
           %span= internal_note.content
 
-- if policy(brand).subscription? || Flipper.enabled?(:skip_subscription_check)
+- if policy(brand).subscription? || Flipper.enabled?(:disable_subscriptions)
   .row.ml-lg-3.justify-content-around.justify-content-lg-start{ id: "toggle-buttons-#{ticket.id}" }
     - if policy(ticket).reply?
       = button_tag fa_icon('reply'), class: 'btn btn-light', id: "toggle-reply-#{ticket.id}",

--- a/docs/development.md
+++ b/docs/development.md
@@ -72,7 +72,7 @@ To integrate a new provider:
 Document all feature flags introduced in the code. Along with the feature
 flag name provide what it does and when it should be removed.
 
-- `skip_subscription_check`
+- `disable_subscriptions`
   - WHAT: Skips subscription checks for features
   - REMOVE: After BETA
 

--- a/spec/policies/brand_policy_spec.rb
+++ b/spec/policies/brand_policy_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe BrandPolicy, type: :policy do
 
   permissions :subscription? do
     it 'allows if subscription checks are skipped' do
-      allow(Flipper).to receive(:enabled?).with(:skip_subscription_check).and_return(true)
+      allow(Flipper).to receive(:enabled?).with(:disable_subscriptions).and_return(true)
 
       expect(brand_policy).to permit(nil, brand)
     end

--- a/spec/views/brands/edit.html.haml_spec.rb
+++ b/spec/views/brands/edit.html.haml_spec.rb
@@ -32,27 +32,51 @@ RSpec.describe 'brands/edit', type: :view do
     expect(render).to have_field('brand[domain]')
   end
 
-  context 'when brand has subscription' do
+  context 'when subscriptions are enabled' do
     before do
-      FactoryBot.create(:subscription, brand: brand)
+      allow(Flipper).to receive(:enabled?).with(:disable_subscriptions).and_return(false)
+    end
+
+    context 'when brand has subscription' do
+      before do
+        FactoryBot.create(:subscription, brand: brand)
+      end
+
+      it 'does not show buy subscription button' do
+        expect(render).not_to have_button('buy-subscription')
+      end
+
+      it 'shows update subscription button' do
+        expect(render).to have_button('update-subscription')
+      end
+
+      it 'shows cancel subscription button' do
+        expect(render).to have_button('cancel-subscription')
+      end
+    end
+
+    context 'when brand does not have subscription' do
+      it 'shows buy subscription button' do
+        expect(render).to have_button('buy-subscription')
+      end
+
+      it 'does not show update subscription button' do
+        expect(render).not_to have_button('update-subscription')
+      end
+
+      it 'does not show cancel subscription button' do
+        expect(render).not_to have_button('cancel-subscription')
+      end
+    end
+  end
+
+  context 'when subscriptions are disabled' do
+    before do
+      allow(Flipper).to receive(:enabled?).with(:disable_subscriptions).and_return(true)
     end
 
     it 'does not show buy subscription button' do
       expect(render).not_to have_button('buy-subscription')
-    end
-
-    it 'shows update subscription button' do
-      expect(render).to have_button('update-subscription')
-    end
-
-    it 'shows cancel subscription button' do
-      expect(render).to have_button('cancel-subscription')
-    end
-  end
-
-  context 'when brand does not have subscription' do
-    it 'shows buy subscription button' do
-      expect(render).to have_button('buy-subscription')
     end
 
     it 'does not show update subscription button' do


### PR DESCRIPTION
# Summary

* Hides brand subscription section behind feature flag
* Rename `skip_subscription_check` feature flag to `disable_subscriptions`